### PR TITLE
update requirements to support recent versions of Node.JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ What's inside:
 * Livereload of main process
 * Sass (grouping into 1 file)
 * Base build process with electron-builder
-* Auto saving app boudries (x, y width, height) with electron-settings
+* Auto saving app boundaries (x, y width, height) with electron-settings
 
 
 ## Usage

--- a/fuse.js
+++ b/fuse.js
@@ -88,15 +88,15 @@ Sparky.task("build:main", () => {
 
         return fuse.run().then(() => {
             // launch electron the app
-            const child = spawn('npm', [ 'run', 'start:electron:watch' ], { shell:true, stdio: 'inherit'});
-            // child.stdout.on('data', function(data) {
-            //     console.log(data.toString());
-            //     //Here is where the output goes
-            // });
-            // child.stderr.on('data', function(data) {
-            //     console.error(data.toString());
-            //     //Here is where the error output goes
-            // });
+            const child = spawn('npm', [ 'run', 'start:electron:watch' ], { shell:true, stdio: 'pipe'});
+            child.stdout.on('data', function(data) {
+                console.log(data.toString());
+                //Here is where the output goes
+            });
+            child.stderr.on('data', function(data) {
+                console.error(data.toString());
+                //Here is where the error output goes
+            });
         });
     }
 


### PR DESCRIPTION
fix typo in README.md
change stdio for Electron spawn in "build:main" from "inherit" to "pipe"
uncomment code that works once again