### PR TITLE
Updated versions in Readme to match package.json versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fuse-box-electron-seed
 
-This version works with `FuseBox 2.2.31` `Electron 1.7.5`
+This version works with `FuseBox 4.0.0` `Electron 4.0.4`
 
 What's inside:
 


### PR DESCRIPTION
I was originally not going to use this seed to start my project until I checked `package.json` and noticed that it's actually quite up to date.

This PR changes the versions in the Readme to match the versions actually used.